### PR TITLE
fix: Query parameter `ids` renamed and fixed schema definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MoonShine OpenApi Generator
 
-[Documentation](https:://moonshine-laravel.com/docs/3.x/frontend/api#oag)
+[Documentation](https://moonshine-laravel.com/docs/3.x/frontend/api#oag)
 
 ## Requirements
 

--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -347,12 +347,15 @@ final class GenerateCommand extends Command
                     'operationId' => (string) $alias->append('MassDelete'),
                     'parameters' => [
                         [
-                            'name' => 'ids',
+                            'name' => 'ids[]',
                             'in' => 'query',
                             'required' => true,
                             'schema' => [
-                                ['type' => 'array'],
+                                'type' => 'array',
+                                'items' => ['type' => 'integer'],
                             ],
+                            'style' => 'form',
+                            'explode' => true,
                         ],
                     ],
                     'responses' => $defaultResponses,


### PR DESCRIPTION
Вообще это был PR с фиксами совместимости с 4 версией муна, но там всё ок и ошибок нет. 

Но я ошибку нашел пока тыкал swagger UI - в mass delete ругается что `ids` не массив.

+ поправил ссылку на доку в ридми